### PR TITLE
should call shouldShowRequestPermissionRationale instead

### DIFF
--- a/complete/src/main/java/com/example/android/whileinuselocation/MainActivity.kt
+++ b/complete/src/main/java/com/example/android/whileinuselocation/MainActivity.kt
@@ -202,7 +202,7 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
 
     // TODO: Step 1.0, Review Permissions: Method requests permissions.
     private fun requestForegroundPermissions() {
-        val provideRationale = foregroundPermissionApproved()
+        val provideRationale = shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_FINE_LOCATION)
 
         // If the user denied a previous request, but didn't check "Don't ask again", provide
         // additional rationale.


### PR DESCRIPTION
this call: 
```kotlin
provideRationale = foregroundPermissionApproved()
```
seems to be not the right implementation. it should invoke _shouldShowRequestPermissionRationale()_ instead.