### PR TITLE
BuildConfig: Deprecate APPLICATION_ID

### DIFF
--- a/base/src/main/java/com/example/android/whileinuselocation/MainActivity.kt
+++ b/base/src/main/java/com/example/android/whileinuselocation/MainActivity.kt
@@ -35,6 +35,7 @@ import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import androidx.viewbinding.BuildConfig
 import com.google.android.material.snackbar.Snackbar
 
 private const val TAG = "MainActivity"
@@ -263,7 +264,7 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
                             intent.action = Settings.ACTION_APPLICATION_DETAILS_SETTINGS
                             val uri = Uri.fromParts(
                                 "package",
-                                BuildConfig.APPLICATION_ID,
+                                BuildConfig.LIBRARY_PACKAGE_NAME,
                                 null
                             )
                             intent.data = uri

--- a/complete/src/main/java/com/example/android/whileinuselocation/MainActivity.kt
+++ b/complete/src/main/java/com/example/android/whileinuselocation/MainActivity.kt
@@ -35,6 +35,7 @@ import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import androidx.viewbinding.BuildConfig
 import com.google.android.material.snackbar.Snackbar
 
 private const val TAG = "MainActivity"
@@ -260,7 +261,7 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
                             intent.action = Settings.ACTION_APPLICATION_DETAILS_SETTINGS
                             val uri = Uri.fromParts(
                                 "package",
-                                BuildConfig.APPLICATION_ID,
+                                BuildConfig.LIBRARY_PACKAGE_NAME,
                                 null
                             )
                             intent.data = uri


### PR DESCRIPTION
https://android.googlesource.com/platform/tools/base/+/51644d6f302ea8c3616d98afde0b4ee30d7d4741

BuildConfig: Deprecate APPLICATION_ID in libraries.

It is at best misleading, so it is marked as deprecated and replaced by
LIBRARY_PACKAGE_NAME.